### PR TITLE
Fix numbering of pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,14 +6,14 @@ Hello, and welcome! Thanks you for your contribution to **Chordly**.
       - [ ] Does it fix a bug?
       - [ ] Does it add new functionality?      
 
-1. Assuming there is a code change in this contribution
+2. Assuming there is a code change in this contribution
    - [ ] Have you included unit test(s) to verify the change?
    - [ ] Do all pre-existing unit tests pass as expected?
    - [ ] Does the change break existing functionality, if so have you explained why doing so is necessary?
    - [ ] Have you listed the possible side-effects or negative impacts of the code change.
 
-1. Put `closes #XXXX` in your comment, where XXXX is the the issue that your PR fixes.
-1. Provide any other information that pertinent to the PR you're making. 
-1. Click "Create pull request".
+3. Put `closes #XXXX` in your comment, where XXXX is the the issue that your PR fixes.
+4. Provide any other information that pertinent to the PR you're making. 
+5. Click "Create pull request".
 
 Thanks again, we'll review your PR and and act accordingly.


### PR DESCRIPTION
When not rendered markdown the pull request template looks terrible. By using human understandable numbering it fixes this issue.

Closes #17, #18

1. Please let us know about the contribution you are making
   - [X] Does this contribution update documentation?
   - [ ] Does this contribution update code?
      - [ ] Does it fix a bug?
      - [ ] Does it add new functionality?      
